### PR TITLE
Add Example: FastUI as Sub-Application

### DIFF
--- a/chat-app/README.md
+++ b/chat-app/README.md
@@ -1,1 +1,0 @@
-# Chat App

--- a/message-board/README.md
+++ b/message-board/README.md
@@ -1,0 +1,6 @@
+# Message Board
+
+- Inspiration:
+  - [shroominic/fastui-chat: 💬 minimalistic ChatBot Interface in pure python](https://github.com/shroominic/fastui-chat)
+  - [Fastui-chat/src/fastui_chat/chat.py at main · mem15381/Fastui-chat](https://github.com/mem15381/Fastui-chat/blob/main/src/fastui_chat/chat.py)
+  - [koyeb/example-fastui-chatbot](https://github.com/koyeb/example-fastui-chatbot)

--- a/message-board/main.py
+++ b/message-board/main.py
@@ -1,0 +1,29 @@
+# Copyright 2024 Hasan Sezer Taşan <hasansezertasan@gmail.com>
+# Copyright (C) 2024 <hasansezertasan@gmail.com>
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from fastui import AnyComponent, FastUI, prebuilt_html
+from fastui import components as c
+from fastui.events import GoToEvent
+from typing_extensions import TypedDict
+
+
+class DisplayAlias(TypedDict):
+    command: str
+    output: str
+
+
+app = FastAPI()
+
+
+@app.get("/api/", response_model=FastUI, response_model_exclude_none=True)
+def page() -> list[AnyComponent]:
+    return []
+
+
+@app.get("/{path:path}")
+def root() -> HTMLResponse:
+    """Simple HTML page which serves the React app, comes last as it matches all paths."""
+    return HTMLResponse(prebuilt_html(title="FastUI Message Board"))

--- a/sub-application/README.md
+++ b/sub-application/README.md
@@ -1,0 +1,3 @@
+# FastUI as Sub-Application
+
+Example, in response to these two issues: [pydantic/FastUI#311](https://github.com/pydantic/FastUI/issues/311) and [pydantic/FastUI#134](https://github.com/pydantic/FastUI/issues/134), of using FastUI as a sub-application is used to demonstrate the fix.

--- a/sub-application/README.md
+++ b/sub-application/README.md
@@ -1,3 +1,3 @@
 # FastUI as Sub-Application
 
-Example, in response to these two issues: [pydantic/FastUI#311](https://github.com/pydantic/FastUI/issues/311) and [pydantic/FastUI#134](https://github.com/pydantic/FastUI/issues/134), of using FastUI as a sub-application is used to demonstrate the fix.
+Example, in response to these two issues: [pydantic/FastUI#311](https://github.com/pydantic/FastUI/issues/311) and [pydantic/FastUI#134](https://github.com/pydantic/FastUI/issues/134), of using FastUI as a sub-application.

--- a/sub-application/main.py
+++ b/sub-application/main.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Hasan Sezer Taşan <hasansezertasan@gmail.com>
+# Copyright (C) 2024 <hasansezertasan@gmail.com>
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from fastui import AnyComponent, FastUI, prebuilt_html
+from fastui import components as c
+
+fooapp = FastAPI()
+
+
+@fooapp.get("/api/", response_model=FastUI, response_model_exclude_none=True)
+def foo_page() -> list[AnyComponent]:
+    return [c.Heading(text="Sub Application Foo API!")]
+
+
+@fooapp.get("/{path:path}")
+def foo_root() -> HTMLResponse:
+    """Simple HTML page which serves the React app, comes last as it matches all paths."""
+    return HTMLResponse(
+        prebuilt_html(
+            title="Sub Application Foo",
+            api_root_url="/foo/api",
+            api_path_strip="/foo",
+        )
+    )
+
+
+barapp = FastAPI()
+
+
+@barapp.get("/api/v1/", response_model=FastUI, response_model_exclude_none=True)
+def bar_page() -> list[AnyComponent]:
+    return [c.Heading(text="Sub Application Bar API!")]
+
+
+@barapp.get("/{path:path}")
+def bar_root() -> HTMLResponse:
+    """Simple HTML page which serves the React app, comes last as it matches all paths."""
+    return HTMLResponse(
+        prebuilt_html(
+            title="Sub Application Bar",
+            api_root_url="/bar/api/v1",
+            api_path_strip="/bar",
+        )
+    )
+
+
+app = FastAPI()
+app.mount("/foo", fooapp)
+app.mount("/bar", barapp)


### PR DESCRIPTION
Example, in response to these two issues: pydantic/FastUI#311 and pydantic/FastUI#134, of using FastUI as a sub-application.

Fixes: #16 