### PR TITLE
fix(robyn): fix catch-all route for prebuilt_html (#27)

### DIFF
--- a/examples/robyn_fastui/app.py
+++ b/examples/robyn_fastui/app.py
@@ -1,9 +1,12 @@
 # Copyright (C) 2024 Hasan Sezer Taşan <hasansezertasan@gmail.com>
 from __future__ import annotations
 
+from typing import cast
+
 from fastui import AnyComponent, FastUI, prebuilt_html
 from fastui import components as c
 from robyn import Headers, Request, Response, Robyn, jsonify, status_codes
+
 
 def setup_fastui() -> None:
     """Register FastUI components and rebuild models.
@@ -18,13 +21,13 @@ setup_fastui()
 app = Robyn(__file__)
 
 
-@app.get("/api/")
-def page(request: Request) -> str:
-    return jsonify(FastUI(root=[c.Heading(text="Hello World")]).model_dump())
+@app.get("/api/")  # type: ignore[misc]
+def page(request: Request) -> Response:
+    return cast(Response, jsonify(FastUI(root=[c.Heading(text="Hello World")]).model_dump()))
 
 
-@app.get("/*path")
-@app.get("/")
+@app.get("/*path")  # type: ignore[misc]
+@app.get("/")  # type: ignore[misc]
 def root(request: Request) -> Response:
     """Simple HTML page which serves the React app, comes last as it matches all paths."""
     return Response(

--- a/examples/robyn_fastui/app.py
+++ b/examples/robyn_fastui/app.py
@@ -24,7 +24,8 @@ app = Robyn(__file__)
 @app.get("/api/")  # type: ignore[misc]
 def page(request: Request) -> Response:
     return cast(
-        "Response", jsonify(FastUI(root=[c.Heading(text="Hello World")]).model_dump()),
+        "Response",
+        jsonify(FastUI(root=[c.Heading(text="Hello World")]).model_dump()),
     )
 
 

--- a/examples/robyn_fastui/app.py
+++ b/examples/robyn_fastui/app.py
@@ -5,8 +5,16 @@ from fastui import AnyComponent, FastUI, prebuilt_html
 from fastui import components as c
 from robyn import Headers, Request, Response, Robyn, jsonify, status_codes
 
-FastUI.model_rebuild(_types_namespace={"AnyComponent": AnyComponent})
+def setup_fastui() -> None:
+    """Register FastUI components and rebuild models.
 
+    This ensures that AnyComponent and other FastUI types are correctly
+    recognized within the Pydantic models when used with Robyn.
+    """
+    FastUI.model_rebuild(_types_namespace={"AnyComponent": AnyComponent})
+
+
+setup_fastui()
 app = Robyn(__file__)
 
 

--- a/examples/robyn_fastui/app.py
+++ b/examples/robyn_fastui/app.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2024 Hasan Sezer Taşan <hasansezertasan@gmail.com>
 from __future__ import annotations
 
-from fastui import FastUI, prebuilt_html
+from fastui import AnyComponent, FastUI, prebuilt_html
 from fastui import components as c
 from robyn import Headers, Request, Response, Robyn, jsonify, status_codes
+
+FastUI.model_rebuild(_types_namespace={"AnyComponent": AnyComponent})
 
 app = Robyn(__file__)
 
@@ -13,6 +15,7 @@ def page(request: Request) -> str:
     return jsonify(FastUI(root=[c.Heading(text="Hello World")]).model_dump())
 
 
+@app.get("/*path")
 @app.get("/")
 def root(request: Request) -> Response:
     """Simple HTML page which serves the React app, comes last as it matches all paths."""

--- a/examples/robyn_fastui/app.py
+++ b/examples/robyn_fastui/app.py
@@ -23,7 +23,9 @@ app = Robyn(__file__)
 
 @app.get("/api/")  # type: ignore[misc]
 def page(request: Request) -> Response:
-    return cast(Response, jsonify(FastUI(root=[c.Heading(text="Hello World")]).model_dump()))
+    return cast(
+        Response, jsonify(FastUI(root=[c.Heading(text="Hello World")]).model_dump())
+    )
 
 
 @app.get("/*path")  # type: ignore[misc]

--- a/examples/robyn_fastui/app.py
+++ b/examples/robyn_fastui/app.py
@@ -24,7 +24,7 @@ app = Robyn(__file__)
 @app.get("/api/")  # type: ignore[misc]
 def page(request: Request) -> Response:
     return cast(
-        Response, jsonify(FastUI(root=[c.Heading(text="Hello World")]).model_dump())
+        "Response", jsonify(FastUI(root=[c.Heading(text="Hello World")]).model_dump()),
     )
 
 

--- a/examples/robyn_fastui/tests/test_app.py
+++ b/examples/robyn_fastui/tests/test_app.py
@@ -14,7 +14,7 @@ from robyn.robyn import HttpMethod
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from robyn import Request, Robyn
+    from robyn import Request, Response, Robyn
 
 
 def load_example_module() -> ModuleType:
@@ -38,7 +38,11 @@ def test_robyn_app_registers_api_root_and_shell_routes() -> None:
     """Register API, root, and wildcard shell routes in matching order."""
     module = load_example_module()
     app = cast("Robyn", module.app)
-    routes = [route.route for route in app.router.get_routes() if route.route_type == HttpMethod.GET]
+    routes = [
+        route.route
+        for route in app.router.get_routes()
+        if route.route_type == HttpMethod.GET
+    ]
 
     # Check for presence and relative ordering of critical routes
     # API should come before root/wildcard to avoid being shadowed
@@ -51,7 +55,7 @@ def test_robyn_app_registers_api_root_and_shell_routes() -> None:
 def test_robyn_api_route_returns_fastui_json() -> None:
     """Serialize the FastUI component tree for the API route."""
     module = load_example_module()
-    page = cast("Callable[[Request], object]", module.page)
+    page = cast("Callable[[Request], Response]", module.page)
 
     response = page(cast("Request", object()))
     description = cast("bytes", response.description)

--- a/examples/robyn_fastui/tests/test_app.py
+++ b/examples/robyn_fastui/tests/test_app.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2024 Hasan Sezer Taşan <hasansezertasan@gmail.com>
+"""Tests for the Robyn FastUI example."""
+
+# ruff: noqa: S101
+
+import json
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING, cast
+
+from robyn.robyn import HttpMethod
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from robyn import Request, Robyn
+
+
+def load_example_module() -> ModuleType:
+    """Load the example module from its file path.
+
+    Raises:
+        ImportError: If the example module spec cannot be loaded.
+    """
+    module_path = Path(__file__).parents[1] / "app.py"
+    spec = spec_from_file_location("robyn_fastui_app", module_path)
+    if spec is None or spec.loader is None:
+        msg = f"Unable to load module from {module_path}"
+        raise ImportError(msg)
+
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_robyn_app_registers_api_root_and_shell_routes() -> None:
+    """Register API, root, and wildcard shell routes in matching order."""
+    module = load_example_module()
+    app = cast("Robyn", module.app)
+    routes = [(route.route_type, route.route) for route in app.router.get_routes()]
+
+    assert routes == [
+        (HttpMethod.GET, "/api/"),
+        (HttpMethod.GET, "/"),
+        (HttpMethod.GET, "/*path"),
+    ]
+
+
+def test_robyn_api_route_returns_fastui_json() -> None:
+    """Serialize the FastUI component tree for the API route."""
+    module = load_example_module()
+    page = cast("Callable[[Request], object]", module.page)
+
+    response = page(cast("Request", object()))
+    description = cast("bytes", response.description)
+
+    assert json.loads(description) == [
+        {
+            "class_name": None,
+            "html_id": None,
+            "level": 1,
+            "text": "Hello World",
+            "type": "Heading",
+        },
+    ]

--- a/examples/robyn_fastui/tests/test_app.py
+++ b/examples/robyn_fastui/tests/test_app.py
@@ -38,13 +38,14 @@ def test_robyn_app_registers_api_root_and_shell_routes() -> None:
     """Register API, root, and wildcard shell routes in matching order."""
     module = load_example_module()
     app = cast("Robyn", module.app)
-    routes = [(route.route_type, route.route) for route in app.router.get_routes()]
+    routes = [route.route for route in app.router.get_routes() if route.route_type == HttpMethod.GET]
 
-    assert routes == [
-        (HttpMethod.GET, "/api/"),
-        (HttpMethod.GET, "/"),
-        (HttpMethod.GET, "/*path"),
-    ]
+    # Check for presence and relative ordering of critical routes
+    # API should come before root/wildcard to avoid being shadowed
+    expected_order = ["/api/", "/", "/*path"]
+    actual_order = [r for r in routes if r in expected_order]
+
+    assert actual_order == expected_order
 
 
 def test_robyn_api_route_returns_fastui_json() -> None:


### PR DESCRIPTION
This PR fixes the issue where the root router in the Robyn example fails to match all paths when serving `prebuilt_html`.

### Changes
- Added `/*path` wildcard route to match all sub-paths.
- Added `FastUI.model_rebuild` for `AnyComponent` to ensure type consistency.
- Added automated tests in `examples/robyn_fastui/tests/test_app.py` to verify:
    - Proper route registration (wildcard route presence).
    - API serialization functionality.

Fixes #27

## Summary by Sourcery

Fix the Robyn FastUI example so the HTML shell correctly catches all routes and the FastUI model is properly configured for serialization.

Bug Fixes:
- Ensure the Robyn root HTML route includes a wildcard path so the prebuilt FastUI app is served for all sub-paths.

Enhancements:
- Configure FastUI with AnyComponent via model_rebuild to maintain type consistency in the example.

Tests:
- Add tests for the Robyn FastUI example to verify API routing, wildcard/root route registration order, and FastUI JSON serialization output.