### PR TITLE
feat(examples): add table with serverload example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Each example is a separate project and ordered by complexity.
 - [Random Number Generator](./examples/random_number_generator/)
 - [Simple Form: BMI Calculator](./examples/simple_form/)
 - [Basic Components Gallery](./examples/basic_component_gallery/)
+- [Table with ServerLoad Example](./examples/table_server_load/)
 - FastUI with other frameworks:
   - [Starlette Example](./examples/starlette_fastui/)
   - [Litestar Example](./examples/litestar_fastui/)

--- a/TODO.md
+++ b/TODO.md
@@ -24,3 +24,5 @@ Used Components:
   - [DevCard - Bootstrap 5 vCard & Portfolio Template for Software Developers](https://themes.3rdwavemedia.com/bootstrap-templates/resume/devcard-bootstrap-5-vcard-portfolio-template-for-software-developers/)
 
 ## Table Component
+
+- [x] [Table with ServerLoad Example](./examples/table_server_load/README.md)

--- a/examples/table_server_load/README.md
+++ b/examples/table_server_load/README.md
@@ -1,0 +1,21 @@
+# FastUI Table with ServerLoad Example
+
+This example demonstrates how to pass an `id` from a table row to a `ServerLoad` component using `PageEvent` in FastUI.
+
+This pattern is useful for loading additional details for a specific item when a user clicks on a row in a table.
+
+## Key Concepts
+
+1.  **`DisplayLookup` with `on_click`**: Each row in the table can have an `on_click` event.
+2.  **`PageEvent` with `context`**: We use `PageEvent` to trigger an update to the page's state. The `context` dictionary allows us to pass variables from the row (using `{field_name}` syntax) into the page state.
+3.  **`ServerLoad` with dynamic path**: The `ServerLoad` component listens for the `PageEvent` and uses the variable from the page state in its `path`.
+
+## How to run
+
+You can run this example using `uv`:
+
+```bash
+uv run main.py
+```
+
+Then open your browser at [http://localhost:8000/](http://localhost:8000/).

--- a/examples/table_server_load/main.py
+++ b/examples/table_server_load/main.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2024 Hasan Sezer Taşan <hasansezertasan@gmail.com>
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "fastapi",
+#     "fastui>=0.6.0",
+#     "uvicorn",
+#     "pydantic>=2.0.0",
+# ]
+# ///
+from __future__ import annotations
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from fastui import AnyComponent, FastUI, prebuilt_html
+from fastui import components as c
+from fastui.components.display import DisplayLookup
+from fastui.events import PageEvent
+from pydantic import BaseModel, Field
+
+FastUI.model_rebuild()
+
+app = FastAPI()
+
+
+class User(BaseModel):
+    id: int = Field(title="ID")
+    name: str = Field(title="Name")
+    role: str = Field(title="Role")
+
+
+users = [
+    User(id=1, name="Alice", role="Admin"),
+    User(id=2, name="Bob", role="User"),
+    User(id=3, name="Charlie", role="Developer"),
+]
+
+
+@app.get("/api/", response_model=FastUI, response_model_exclude_none=True)
+def users_table() -> list[AnyComponent]:
+    return [
+        c.Page(
+            components=[
+                c.Heading(text="Users", level=2),
+                c.Paragraph(text="Click on a user ID to see their details below."),
+                c.Table(
+                    data=users,
+                    data_model=User,
+                    columns=[
+                        DisplayLookup(
+                            field="id",
+                            on_click=PageEvent(
+                                name="user-details",
+                                context={"user_id": "{id}"},
+                            ),
+                        ),
+                        DisplayLookup(field="name"),
+                        DisplayLookup(field="role"),
+                    ],
+                ),
+                c.Div(
+                    components=[
+                        c.ServerLoad(
+                            path="/user-details/{user_id}",
+                            load_trigger=PageEvent(name="user-details"),
+                            components=[c.Text(text="Select a user to see details...")],
+                        ),
+                    ],
+                    class_name="border-top mt-3 pt-3",
+                ),
+            ],
+        ),
+    ]
+
+
+@app.get(
+    "/api/user-details/{user_id}",
+    response_model=FastUI,
+    response_model_exclude_none=True,
+)
+def user_details(user_id: int) -> list[AnyComponent]:
+    user = next((u for u in users if u.id == user_id), None)
+    if user is None:
+        return [c.Text(text="User not found")]
+
+    return [
+        c.Heading(text=f"Details for {user.name}", level=3),
+        c.Paragraph(text=f"ID: {user.id}"),
+        c.Paragraph(text=f"Role: {user.role}"),
+    ]
+
+
+@app.get("/{path:path}")
+async def html_landing() -> HTMLResponse:
+    return HTMLResponse(prebuilt_html(title="FastUI Table ServerLoad Example"))
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/examples/table_server_load/main.py
+++ b/examples/table_server_load/main.py
@@ -23,6 +23,8 @@ FastUI.model_rebuild()
 
 app = FastAPI()
 
+USER_DETAILS_EVENT = "user-details"
+
 
 class User(BaseModel):
     id: int = Field(title="ID")
@@ -51,7 +53,7 @@ def users_table() -> list[AnyComponent]:
                         DisplayLookup(
                             field="id",
                             on_click=PageEvent(
-                                name="user-details",
+                                name=USER_DETAILS_EVENT,
                                 context={"user_id": "{id}"},
                             ),
                         ),
@@ -62,8 +64,8 @@ def users_table() -> list[AnyComponent]:
                 c.Div(
                     components=[
                         c.ServerLoad(
-                            path="/user-details/{user_id}",
-                            load_trigger=PageEvent(name="user-details"),
+                            path="/api/user-details/{user_id}",
+                            load_trigger=PageEvent(name=USER_DETAILS_EVENT),
                             components=[c.Text(text="Select a user to see details...")],
                         ),
                     ],

--- a/examples/table_server_load/requirements.txt
+++ b/examples/table_server_load/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+fastui>=0.6.0
+uvicorn
+pydantic>=2.0.0


### PR DESCRIPTION
This PR adds a new example demonstrating how to pass an ID from a table row to a ServerLoad component using PageEvent in FastUI. Fixes #32.

## Summary by Sourcery

Add a new FastUI example demonstrating passing a table row ID into a ServerLoad component via PageEvent and link it from the main documentation and TODO list.

New Features:
- Introduce a table_server_load FastAPI example showcasing loading user details from a table selection using FastUI components.

Documentation:
- Document the new table_server_load example with usage explanation and run instructions, and link it from the main README and TODO checklist.